### PR TITLE
Remove datasource/connection logger management (fixes #139)

### DIFF
--- a/src/js/store/api/resources/remotes/actions.ts
+++ b/src/js/store/api/resources/remotes/actions.ts
@@ -4,14 +4,6 @@ import { createAction } from 'redux-actions';
 import { CONN_MAP_REVERSE } from '../../../../constants/remotes';
 import { attrsSelector } from '../../../../helpers/remotes';
 import settings from '../../../../settings';
-import {
-  addAppenderAction,
-  addUpdateLoggerAction,
-  deleteAppenderAction,
-  deleteLoggerAction,
-  editAppenderAction,
-  fetchLoggerAction,
-} from '../../common/actions';
 import { fetchJson, fetchWithNotifications, get, put } from '../../utils';
 
 const ping: Function = (model: string, type: string, dispatch: Function) =>
@@ -220,13 +212,6 @@ const resetConnection: Function = createAction(
   }
 );
 
-const fetchLogger = fetchLoggerAction('remotes', 'remote/datasources');
-const addUpdateLogger = addUpdateLoggerAction('remotes', 'remote/datasources');
-const deleteLogger = deleteLoggerAction('remotes', 'remote/datasources');
-const addAppender = addAppenderAction('remotes', 'remote/datasources');
-const editAppender = editAppenderAction('remotes', 'remote/datasources');
-const deleteAppender = deleteAppenderAction('remotes', 'remote/datasources');
-
 export {
   pingRemote,
   connectionChange,
@@ -244,10 +229,4 @@ export {
   addConnection,
   updateConnection,
   removeConnectionWS,
-  fetchLogger,
-  addUpdateLogger,
-  deleteLogger,
-  addAppender,
-  editAppender,
-  deleteAppender,
 };

--- a/src/js/store/api/resources/remotes/reducers.ts
+++ b/src/js/store/api/resources/remotes/reducers.ts
@@ -1,14 +1,6 @@
 import omit from 'lodash/omit';
 import remove from 'lodash/remove';
 import { CONN_MAP_REVERSE } from '../../../../constants/remotes';
-import {
-  addAppenderReducer,
-  addUpdateLoggerReducer,
-  deleteAppenderReducer,
-  deleteLoggerReducer,
-  editAppenderReducer,
-  loggerReducer,
-} from '../../common/reducers';
 import { setUpdatedToNull, updateItemWithName } from '../../utils';
 
 const initialState = {
@@ -350,28 +342,14 @@ const removeConnectionWs = {
   },
 };
 
-// LOGGER
-const fetchLogger = loggerReducer;
-const addUpdateLogger = addUpdateLoggerReducer;
-const deleteLogger = deleteLoggerReducer;
-const addAppender = addAppenderReducer;
-const editAppender = editAppenderReducer;
-const deleteAppender = deleteAppenderReducer;
-
 export {
   addAlert as ADDALERT,
-  addAppender as ADDAPPENDER,
   addConnection as ADDCONNECTION,
-  addUpdateLogger as ADDUPDATELOGGER,
   clearAlert as CLEARALERT,
   connectionChange as CONNECTIONCHANGE,
   debugChange as DEBUGCHANGE,
-  deleteAppender as DELETEAPPENDER,
   deleteConnection as DELETECONNECTION,
-  deleteLogger as DELETELOGGER,
-  editAppender as EDITAPPENDER,
   enabledChange as ENABLEDCHANGE,
-  fetchLogger as FETCHLOGGER,
   fetchPass as FETCHPASS,
   manageConnection as MANAGECONNECTION,
   pingRemote as PINGREMOTE,

--- a/src/js/store/apievents/actions.ts
+++ b/src/js/store/apievents/actions.ts
@@ -991,10 +991,6 @@ const handleEvent = (url, data, dispatch, state) => {
       case 'LOGGER_CREATED':
       case 'LOGGER_UPDATED': {
         const newInfo: any = { ...info };
-        // @ts-ignore ts-migrate(2339) FIXME: Property 'interface' does not exist on type 'Objec... Remove this comment to see the full error message
-        newInfo.interface =
-          // @ts-ignore ts-migrate(2339) FIXME: Property 'interface' does not exist on type 'Objec... Remove this comment to see the full error message
-          newInfo.interface === 'qdsp' ? 'remotes' : newInfo.interface;
         const reversedLevels: any = invert(state.api.system.data.loggerParams.logger_levels);
 
         // @ts-ignore ts-migrate(2339) FIXME: Property 'params' does not exist on type 'Object'.
@@ -1030,10 +1026,6 @@ const handleEvent = (url, data, dispatch, state) => {
       case 'LOGGER_DELETED': {
         // Modify the levels
         const newInfo: any = { ...info };
-        // @ts-ignore ts-migrate(2339) FIXME: Property 'interface' does not exist on type 'Objec... Remove this comment to see the full error message
-        newInfo.interface =
-          // @ts-ignore ts-migrate(2339) FIXME: Property 'interface' does not exist on type 'Objec... Remove this comment to see the full error message
-          newInfo.interface === 'qdsp' ? 'remotes' : newInfo.interface;
         // Check if default logger was deleted
         // @ts-ignore ts-migrate(2339) FIXME: Property 'isDefault' does not exist on type 'Objec... Remove this comment to see the full error message
         if (newInfo.isDefault) {
@@ -1069,7 +1061,6 @@ const handleEvent = (url, data, dispatch, state) => {
       }
       case 'APPENDER_CREATED': {
         const newInfo = { ...info };
-        newInfo.interface = newInfo.interface === 'qdsp' ? 'remotes' : newInfo.interface;
         // Create default appender
         if (info.isDefault) {
           pipeline('APPENDER_ACTIONS', system.addDefaultAppender, newInfo, dispatch);
@@ -1093,7 +1084,6 @@ const handleEvent = (url, data, dispatch, state) => {
       }
       case 'APPENDER_UPDATED': {
         const newInfo = { ...info };
-        newInfo.interface = newInfo.interface === 'qdsp' ? 'remotes' : newInfo.interface;
         // Create default appender
         if (info.isDefault) {
           pipeline('APPENDER_ACTIONS', system.editDefaultAppender, newInfo, dispatch);
@@ -1117,7 +1107,6 @@ const handleEvent = (url, data, dispatch, state) => {
       }
       case 'APPENDER_DELETED': {
         const newInfo = { ...info };
-        newInfo.interface = newInfo.interface === 'qdsp' ? 'remotes' : newInfo.interface;
 
         // Create default appender
         if (newInfo.isDefault) {

--- a/src/js/views/root.tsx
+++ b/src/js/views/root.tsx
@@ -296,8 +296,6 @@ export default class Root extends Component {
       this.props.fetchDefaultLogger('workflows'),
       // @ts-ignore ts-migrate(2339) FIXME: Property 'fetchDefaultLogger' does not exist on ty... Remove this comment to see the full error message
       this.props.fetchDefaultLogger('jobs'),
-      // @ts-ignore ts-migrate(2339) FIXME: Property 'fetchDefaultLogger' does not exist on ty... Remove this comment to see the full error message
-      this.props.fetchDefaultLogger('remotes', 'remote/datasources'),
     ]);
 
     this.props.fetchSystemOptions();

--- a/src/js/views/system/connections/pane.tsx
+++ b/src/js/views/system/connections/pane.tsx
@@ -16,12 +16,10 @@ import { createSelector } from 'reselect';
 import NameColumn from '../../../components/NameColumn';
 import { SimpleTab, SimpleTabs } from '../../../components/SimpleTabs';
 import AlertsTable from '../../../components/alerts_table';
-import Box from '../../../components/box';
 import { Table, Tbody, Tr } from '../../../components/new_table';
 import NoData from '../../../components/nodata';
 import Pane from '../../../components/pane';
 import PaneItem from '../../../components/pane_item';
-import LogContainer from '../../../containers/log';
 import { attrsSelector } from '../../../helpers/remotes';
 import { getDependencyObjectLink } from '../../../helpers/system';
 import queryControl from '../../../hocomponents/queryControl';
@@ -159,7 +157,7 @@ class ConnectionsPane extends Component {
     // @ts-ignore ts-migrate(2339) FIXME: Property 'deps' does not exist on type 'Object'.
     const { deps, alerts, locked, url_hash } = this.props.remote;
     // @ts-ignore ts-migrate(2339) FIXME: Property 'paneTab' does not exist on type '{ remot... Remove this comment to see the full error message
-    const { paneTab, paneId, remoteType, dispatchAction } = this.props;
+    const { paneTab, remoteType, dispatchAction } = this.props;
     const { isPassLoaded, status, message, messageTitle, messageDuration } = this.state;
 
     const canEdit = !locked && this.props.canEdit;
@@ -170,7 +168,6 @@ class ConnectionsPane extends Component {
       'Detail',
       { title: 'Options', suffix: size(this.props.remote.opts) },
       { title: 'Alerts', suffix: size(alerts) },
-      'Log',
     ];
 
     if (remoteType === 'datasources') {
@@ -336,18 +333,6 @@ class ConnectionsPane extends Component {
               )}
             </PaneItem>
           </SimpleTab>
-          {remoteType === 'datasources' && (
-            <SimpleTab name="log">
-              <Box top fill scrollY>
-                <LogContainer
-                  id={paneId}
-                  intfc="remotes"
-                  url="remote/datasources"
-                  resource={`qdsp/${paneId}`}
-                />
-              </Box>
-            </SimpleTab>
-          )}
         </SimpleTabs>
       </Pane>
     );

--- a/src/js/views/system/logs/index.tsx
+++ b/src/js/views/system/logs/index.tsx
@@ -59,10 +59,6 @@ const Log: Function = ({ tabQuery, logs }: Props) => (
           <ExpandableItem title="Jobs default logger" show>
             {() => <DefaultLogger name="Logger data" defaultOnly resource="jobs" />}
           </ExpandableItem>
-          <br />
-          <ExpandableItem title="Datasources default logger" show>
-            {() => <DefaultLogger name="Logger data" defaultOnly resource="remotes" />}
-          </ExpandableItem>
         </Box>
       </SimpleTab>
     </SimpleTabs>


### PR DESCRIPTION
Fixes #139

## Summary

Datasource pool loggers (and the `qdsp` cluster-datasource-pool process they belonged to) were removed in Qorus 8.0, so the backend no longer implements `defaultLogger` / `defaultLoggerAppenders` for datasources and correctly returns **501 Not Implemented**. This PR restricts logger management in the UI to the resource types the backend actually supports — the interface loggers (`workflows`, `services`, `jobs`) and the system loggers — and removes all datasource/connection logger surfaces:

- **`views/root.tsx`** — drop the `fetchDefaultLogger('remotes', 'remote/datasources')` call on app load. This was the source of the failing `GET /api/latest/remote/datasources?action=defaultLogger` (and the sibling `defaultLoggerAppenders`) requests.
- **`views/system/logs/index.tsx`** — remove the "Datasources default logger" section from the Logs → Default Loggers tab. The remaining sections (system, workflows, services, jobs) match exactly the logger types the backend registers; the system log tabs were already derived from the backend via `loggerParams.configurable_systems`.
- **`views/system/connections/pane.tsx`** — remove the Log tab from the connection detail pane. It streamed the `log/qdsp/<name>` websocket (a process that no longer exists) and exposed per-datasource logger settings (`/remote/datasources/<id>/logger`, also unsupported).
- **`store/api/resources/remotes/{actions,reducers}.ts`** — remove the now-unused logger/appender actions and reducers for the remotes resource.
- **`store/apievents/actions.ts`** — remove the `qdsp` → `remotes` remapping in the `LOGGER_*` / `APPENDER_*` websocket event handlers; the backend can no longer emit logger events for that interface.

No backend change needed, per the issue.

## Testing

- `yarn build:pr` passes.
- Verified no remaining references to remotes/datasource loggers: all remaining `LogContainer`/`Logger` usages pass `intfc` of `workflows`, `services`, `jobs`, or `system` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)